### PR TITLE
Handle multiple TextAnnotations being returned for some documents.

### DIFF
--- a/src/main/java/edu/illinois/cs/cogcomp/erc/features/pipeline.java
+++ b/src/main/java/edu/illinois/cs/cogcomp/erc/features/pipeline.java
@@ -13,38 +13,35 @@ import edu.illinois.cs.cogcomp.nlp.pipeline.IllinoisPipelineFactory;
  */
 public class pipeline {
 
-    private static AnnotatorService prep;
+    private static AnnotatorService prep = getAnnotatorServiceInstance();
 
-    public static void addShallowParse(TextAnnotation ta) {
-        ResourceManager pipelineRm = new PipelineConfig().getDefaultConfig();
-        ResourceManager annotatorServiceRm = new AnnotatorServiceConfigurator().getConfig(pipelineRm);
+    private static AnnotatorService getAnnotatorServiceInstance() {
+        if (prep == null) {
+            ResourceManager pipelineRm = new PipelineConfig().getDefaultConfig();
+            ResourceManager annotatorServiceRm = new AnnotatorServiceConfigurator().getConfig(pipelineRm);
 
-        try {
-            prep = IllinoisPipelineFactory.buildPipeline(annotatorServiceRm);
-        } catch (Exception e){
-            e.printStackTrace();
+            try {
+                prep = IllinoisPipelineFactory.buildPipeline(annotatorServiceRm);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
 
-        try{
+        return prep;
+    }
+
+    public static void addShallowParse(TextAnnotation ta) {
+        try {
             prep.addView(ta, ViewNames.SHALLOW_PARSE);
-        } catch (Exception e){
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
 
     public static void addPOS(TextAnnotation ta) {
-        ResourceManager pipelineRm = new PipelineConfig().getDefaultConfig();
-        ResourceManager annotatorServiceRm = new AnnotatorServiceConfigurator().getConfig(pipelineRm);
-
         try {
-            prep = IllinoisPipelineFactory.buildPipeline(annotatorServiceRm);
-        } catch (Exception e){
-            e.printStackTrace();
-        }
-
-        try{
             prep.addView(ta, ViewNames.POS);
-        } catch (Exception e){
+        } catch (Exception e) {
             e.printStackTrace();
         }
 

--- a/src/main/java/edu/illinois/cs/cogcomp/erc/ir/Document.java
+++ b/src/main/java/edu/illinois/cs/cogcomp/erc/ir/Document.java
@@ -11,13 +11,13 @@ import java.util.List;
  * Created by Bhargav Mangipudi on 2/26/16.
  */
 public class Document implements Serializable {
-    List<TextAnnotation> taList;
+    TextAnnotation ta;
     ACEDocumentAnnotation aceAnnotation;
     boolean is2004;
     String filename;
 
-    public Document(List<TextAnnotation> taList, ACEDocumentAnnotation aceAnnotation, boolean is2004, String filename) {
-        this.taList = taList;
+    public Document(TextAnnotation ta, ACEDocumentAnnotation aceAnnotation, boolean is2004, String filename) {
+        this.ta = ta;
         this.aceAnnotation = aceAnnotation;
         this.is2004 = is2004;
         this.filename = filename;
@@ -27,14 +27,12 @@ public class Document implements Serializable {
     }
 
     public void addPipeLineViews() {
-        for (TextAnnotation ta : this.taList) {
-            pipeline.addShallowParse(ta);
-            pipeline.addPOS(ta);
-        }
+        pipeline.addShallowParse(ta);
+        pipeline.addPOS(ta);
     }
 
-    public List<TextAnnotation> getTA() {
-        return this.taList;
+    public TextAnnotation getTA() {
+        return this.ta;
     }
 
     public ACEDocumentAnnotation getAceAnnotation() {

--- a/src/main/java/edu/illinois/cs/cogcomp/erc/ir/Document.java
+++ b/src/main/java/edu/illinois/cs/cogcomp/erc/ir/Document.java
@@ -5,30 +5,36 @@ import edu.illinois.cs.cogcomp.erc.features.pipeline;
 import edu.illinois.cs.cogcomp.reader.ace2005.annotationStructure.ACEDocumentAnnotation;
 
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * Created by Bhargav Mangipudi on 2/26/16.
  */
 public class Document implements Serializable {
-    TextAnnotation ta;
+    List<TextAnnotation> taList;
     ACEDocumentAnnotation aceAnnotation;
     boolean is2004;
     String filename;
 
-    public Document(TextAnnotation ta, ACEDocumentAnnotation aceAnnotation, boolean is2004, String filename) {
-        this.ta = ta;
+    public Document(List<TextAnnotation> taList, ACEDocumentAnnotation aceAnnotation, boolean is2004, String filename) {
+        this.taList = taList;
         this.aceAnnotation = aceAnnotation;
         this.is2004 = is2004;
         this.filename = filename;
+
+        // Add Pipeline Views as well
+        this.addPipeLineViews();
     }
 
-    public void addPipeLineViews(){
-        pipeline.addShallowParse(this.ta);
-        pipeline.addPOS(this.ta);
+    public void addPipeLineViews() {
+        for (TextAnnotation ta : this.taList) {
+            pipeline.addShallowParse(ta);
+            pipeline.addPOS(ta);
+        }
     }
 
-    public TextAnnotation getTA() {
-        return this.ta;
+    public List<TextAnnotation> getTA() {
+        return this.taList;
     }
 
     public ACEDocumentAnnotation getAceAnnotation() {

--- a/src/main/java/edu/illinois/cs/cogcomp/erc/main/Main.java
+++ b/src/main/java/edu/illinois/cs/cogcomp/erc/main/Main.java
@@ -5,6 +5,7 @@ import edu.illinois.cs.cogcomp.erc.config.ConfigSystem;
 import edu.illinois.cs.cogcomp.erc.ir.Document;
 import edu.illinois.cs.cogcomp.erc.reader.Ace04Reader;
 import edu.illinois.cs.cogcomp.erc.reader.Ace05Reader;
+import edu.illinois.cs.cogcomp.reader.ace2005.annotationStructure.ACEDocument;
 
 import java.util.List;
 
@@ -16,14 +17,18 @@ public class Main {
     public static void main(String [] args) {
         ConfigSystem.initialize();
 
-        Ace04Reader ace04 = new Ace04Reader();
-        List<Document> ace04Corpus = ace04.readCorpus();
-
-        System.out.println("Number of ACE04 documents read - " + ace04Corpus.size());
+//        Ace04Reader ace04 = new Ace04Reader();
+//        List<Document> ace04Corpus = ace04.readCorpus();
+//
+//        System.out.println("Number of ACE04 documents read - " + ace04Corpus.size());
 
         Ace05Reader ace05 = new Ace05Reader();
-        List<Document> ace05Corpus = ace05.readCorpus();
+//        List<Document> ace05Corpus = ace05.readCorpus();
 
-        System.out.println("Number of ACE05 documents read - " + ace05Corpus.size());
+//        System.out.println("Number of ACE05 documents read - " + ace05Corpus.size());
+
+        String fileName = "bn/CNN_ENG_20030506_160524.18.apf.xml";
+        ace05.readDocument(fileName);
+
     }
 }

--- a/src/main/java/edu/illinois/cs/cogcomp/erc/main/Main.java
+++ b/src/main/java/edu/illinois/cs/cogcomp/erc/main/Main.java
@@ -17,18 +17,15 @@ public class Main {
     public static void main(String [] args) {
         ConfigSystem.initialize();
 
-//        Ace04Reader ace04 = new Ace04Reader();
-//        List<Document> ace04Corpus = ace04.readCorpus();
-//
-//        System.out.println("Number of ACE04 documents read - " + ace04Corpus.size());
+        Ace04Reader ace04 = new Ace04Reader();
+        List<Document> ace04Corpus = ace04.readCorpus();
+
+        System.out.println("Number of ACE04 documents read - " + ace04Corpus.size());
 
         Ace05Reader ace05 = new Ace05Reader();
-//        List<Document> ace05Corpus = ace05.readCorpus();
+        List<Document> ace05Corpus = ace05.readCorpus();
 
-//        System.out.println("Number of ACE05 documents read - " + ace05Corpus.size());
-
-        String fileName = "bn/CNN_ENG_20030506_160524.18.apf.xml";
-        ace05.readDocument(fileName);
+        System.out.println("Number of ACE05 documents read - " + ace05Corpus.size());
 
     }
 }

--- a/src/main/java/edu/illinois/cs/cogcomp/erc/reader/Ace04Reader.java
+++ b/src/main/java/edu/illinois/cs/cogcomp/erc/reader/Ace04Reader.java
@@ -1,8 +1,6 @@
 package edu.illinois.cs.cogcomp.erc.reader;
 
-
 import edu.illinois.cs.cogcomp.erc.config.Parameters;
-import edu.illinois.cs.cogcomp.erc.ir.Document;
 
 /**
  * Created by nitishgupta on 2/25/16.
@@ -11,6 +9,7 @@ public class Ace04Reader extends DocumentReader {
 
     public Ace04Reader() {
         super();
+
         this.is2004 = true;
         this.baseDir = Parameters.ACE04_DATA_DIR;
         this.filelistPath = Parameters.ACE04_FILELIST;

--- a/src/main/java/edu/illinois/cs/cogcomp/erc/reader/Ace05Reader.java
+++ b/src/main/java/edu/illinois/cs/cogcomp/erc/reader/Ace05Reader.java
@@ -9,6 +9,7 @@ public class Ace05Reader extends DocumentReader {
 
     public Ace05Reader() {
         super();
+
         this.is2004 = false;
         this.baseDir = Parameters.ACE05_DATA_DIR;
         this.filelistPath = Parameters.ACE05_FILELIST;

--- a/src/main/java/edu/illinois/cs/cogcomp/erc/reader/DocumentReader.java
+++ b/src/main/java/edu/illinois/cs/cogcomp/erc/reader/DocumentReader.java
@@ -50,13 +50,16 @@ public abstract class DocumentReader {
         try {
             ACEDocument doc = fileProcessor.processAceEntry(new File(this.baseDir + prefix + "/"), fullFileName);
             List<TextAnnotation> taList = AceFileProcessor.populateTextAnnotation(doc);
-            assert !taList.isEmpty();
-            Document newDoc = new Document(taList, doc.aceAnnotation, is2004, fileName);
 
-            // Write document to cache
-            Utils.writeSerializedDocument(newDoc, serializedDocDir, cacheFileName);
+            if (taList.size() == 1) {
+                Document newDoc = new Document(taList.get(0), doc.aceAnnotation, is2004, fileName);
 
-            return newDoc;
+                // Write document to cache
+                Utils.writeSerializedDocument(newDoc, serializedDocDir, cacheFileName);
+                return newDoc;
+            }
+
+            return null;
         } catch (Exception ex) {
             if (Parameters.isDebug) System.err.println("Failed to parse document - " + fullFileName);
             if (Parameters.isDebug) ex.printStackTrace(System.err);

--- a/src/main/java/edu/illinois/cs/cogcomp/erc/reader/DocumentReader.java
+++ b/src/main/java/edu/illinois/cs/cogcomp/erc/reader/DocumentReader.java
@@ -49,8 +49,9 @@ public abstract class DocumentReader {
 
         try {
             ACEDocument doc = fileProcessor.processAceEntry(new File(this.baseDir + prefix + "/"), fullFileName);
-            TextAnnotation ta = AceFileProcessor.populateTextAnnotation(doc).get(0);
-            Document newDoc = new Document(ta, doc.aceAnnotation, is2004, fileName);
+            List<TextAnnotation> taList = AceFileProcessor.populateTextAnnotation(doc);
+            assert !taList.isEmpty();
+            Document newDoc = new Document(taList, doc.aceAnnotation, is2004, fileName);
 
             // Write document to cache
             Utils.writeSerializedDocument(newDoc, serializedDocDir, cacheFileName);


### PR DESCRIPTION
- Instead of storing one TA, storing the list of all TA's in the sentence.
- Simple singleton for the IllinoisPipeline AnnotatorService instance.